### PR TITLE
auth: support set security token in query

### DIFF
--- a/auth/signer.go
+++ b/auth/signer.go
@@ -89,8 +89,12 @@ func (b *BceV1Signer) Sign(req *http.Request, cred *BceCredentials, opt *SignOpt
 	}
 
 	// Set security token if using session credentials
-	if len(cred.SessionToken) != 0 {
-		req.SetHeader(http.BCE_SECURITY_TOKEN, cred.SessionToken)
+	// if has security token in query then do nothing, or add security token 
+	// to header
+	if len(req.Param(http.BCE_SECURITY_TOKEN)) == 0 {
+		if len(cred.SessionToken) != 0 {
+			req.SetHeader(http.BCE_SECURITY_TOKEN, cred.SessionToken)
+		}
 	}
 
 	// Prepare the canonical request components


### PR DESCRIPTION
if has security token in query, must be user want to set
security token in query, so not add it to header again.

Fixes #25

Signed-off-by: HanChen <hanchen@baidu.com>