### PR TITLE
修复bos sdk中SimpleFetchObject方法内结构体赋值未指定字段名问题,并补充fetchCallBackAddress参数

### DIFF
--- a/services/bos/client.go
+++ b/services/bos/client.go
@@ -1108,12 +1108,19 @@ func (c *Client) BasicFetchObject(bucket, object, source string) (*api.FetchObje
 //     - source: fetch source url
 //     - mode: fetch mode which supports sync and async
 //     - storageClass: the storage class of the fetched object
+//     - fetchCallBackAddress: the callback address of the fetched object
 // RETURNS:
 //     - *api.FetchObjectResult: result struct with Code, Message, RequestId and JobId fields
 //     - error: any error if it occurs
 func (c *Client) SimpleFetchObject(bucket, object, source, mode,
-	storageClass string) (*api.FetchObjectResult, error) {
-	args := &api.FetchObjectArgs{mode, storageClass}
+	storageClass, fetchCallBackAddress string) (*api.FetchObjectResult, error) {
+
+	args := &api.FetchObjectArgs{
+		FetchMode:            mode,
+		StorageClass:         storageClass,
+		FetchCallBackAddress: fetchCallBackAddress,
+	}
+
 	return api.FetchObject(c, bucket, object, source, args, c.BosContext)
 }
 

--- a/services/bos/client_test.go
+++ b/services/bos/client_test.go
@@ -791,7 +791,7 @@ func TestBasicFetchObject(t *testing.T) {
 func TestSimpleFetchObject(t *testing.T) {
 	res, err := BOS_CLIENT.SimpleFetchObject(EXISTS_BUCKET, "test-fetch-object",
 		"https://bj.bcebos.com/gosdk-unittest-bucket/testsumlink",
-		api.FETCH_MODE_ASYNC, api.STORAGE_CLASS_COLD)
+		api.FETCH_MODE_ASYNC, api.STORAGE_CLASS_COLD, "")
 	ExpectEqual(t.Errorf, err, nil)
 	t.Logf("result: %+v", res)
 }


### PR DESCRIPTION
Fix: #93